### PR TITLE
Add Meets bloc

### DIFF
--- a/cypress/integration/components/page/pageForm/PageFormObject.ts
+++ b/cypress/integration/components/page/pageForm/PageFormObject.ts
@@ -3,7 +3,7 @@ import { allPages } from "~/routes/tests/PageFormTest"
 import { repeat } from "$lib/utils/strings"
 
 export class BlocObject {
-  protected readonly dataTestId: string
+  public readonly dataTestId: string
 
   constructor(dataTestId: string) {
     this.dataTestId = dataTestId
@@ -25,6 +25,7 @@ export class BlocObject {
     "h5": "h5",
     "h6": "h6",
     "meet": ".meet",
+    "meets": ".meets",
     "img": "figure"
   }
 
@@ -194,6 +195,64 @@ export class MeetBlocObject extends BlocObject {
 
   attributeDatetimeOfTimeShouldBe = (expectedDatetime: string): this => {
     cy.get(`[data-test-id=${this.dataTestId}] time`).should("have.attr", "datetime", expectedDatetime)
+    return this
+  }
+}
+
+export class MeetsBlocObject extends BlocObject {
+  constructor(dataTestId: string) {
+    super(dataTestId)
+  }
+
+  changeDate = (index: number, date: string): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date-editButton]`).click()
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date\\.date-date]`).type(date)
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date-validButton]`).click()
+    return this
+  }
+
+  changeTime = (index: number, time: string): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date-editButton]`).click()
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date\\.date-time]`).type(time)
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date-validButton]`).click()
+    return this
+  }
+
+  changeDateTime = (index: number, date: string, time: string): this => {
+    this.changeDateTimeWithoutValidating(index, date, time)
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date-validButton]`).click()
+    return this
+  }
+
+  changeDateTimeWithoutValidating = (index: number, date: string, time: string): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date-editButton]`).click()
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date\\.date-date]`).type(date)
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date\\.date-time]`).type(time)
+    return this
+  }
+
+  attributeDatetimeOfTimeShouldBe = (index: number, expectedDatetime: string): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date]`).should("have.attr", "datetime", expectedDatetime)
+    return this
+  }
+
+  addItem = (): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-add]`).click()
+    return this
+  }
+
+  deleteItem = (index: number): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-delete]`).click()
+    return this
+  }
+
+  itemShouldExist = (index: number): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date]`).should("exist")
+    return this
+  }
+
+  itemShouldNotExist = (index: number): this => {
+    cy.get(`[data-test-id=${this.dataTestId}-meet-${index}-date]`).should("not.exist")
     return this
   }
 }

--- a/cypress/integration/components/page/pageForm/common.ts
+++ b/cypress/integration/components/page/pageForm/common.ts
@@ -1,5 +1,5 @@
 /// <reference path="../../../../support/index.d.ts" />
-import { ImgBlocObject, MeetBlocObject, PageFormObject, TextBlocObject } from "./PageFormObject"
+import { ImgBlocObject, MeetBlocObject, MeetsBlocObject, PageFormObject, TextBlocObject } from "./PageFormObject"
 
 export const fullPageFormObject = new PageFormObject("initialPage", {
   title1: new TextBlocObject("s6eTVUS5LZ6O3K3FQlPB"),
@@ -14,6 +14,7 @@ export const fullPageFormObject = new PageFormObject("initialPage", {
   secondRichParagraph: new TextBlocObject("7iGFyeZlNddiRpqX3FbN"),
   thirdRichParagraph: new TextBlocObject("n9tAhhR0lup1StIFKCnE"),
   firstMeet: new MeetBlocObject("hBZZT83U4fvFaZq2I1wo"),
+  firstMeets: new MeetsBlocObject("CHK4tT7mOwSyQ9i6XFrU"),
   firstImage: new ImgBlocObject("VGa2gwdqZZ4GjIQv9gLx"),
 })
 

--- a/cypress/integration/components/page/pageForm/meets/dates.ts
+++ b/cypress/integration/components/page/pageForm/meets/dates.ts
@@ -1,0 +1,36 @@
+import { Meets, Page } from "$model/Page"
+import { fullPageFormObject } from "../common"
+
+describe("MeetsEdit dates", () => {
+  it("should update the date of the first item", () => {
+    fullPageFormObject.initialize()
+
+    fullPageFormObject.getBloc("firstMeets").changeDate(0, "2012-12-20")
+    fullPageFormObject.getBloc("firstMeets").attributeDatetimeOfTimeShouldBe(0, "2012-12-20T16:30:00.000Z")
+  })
+
+  it("should update the time of the second item", () => {
+    fullPageFormObject.initialize()
+
+    fullPageFormObject.getBloc("firstMeets").changeTime(1, "08:15")
+    fullPageFormObject.getBloc("firstMeets").attributeDatetimeOfTimeShouldBe(1, "2021-05-23T06:15:00.000Z")
+  })
+
+  it("should save the value in the form", () => {
+    fullPageFormObject.initialize()
+
+    let loggedPage: Page
+    cy.window().then(($win) => {
+      cy.stub($win.console, "log").callsFake(x => loggedPage = x)
+    })
+
+    fullPageFormObject.getBloc("firstMeets").changeDateTimeWithoutValidating(0, "2012-12-20", "08:15")
+    fullPageFormObject.submit()
+
+    cy.should(() => {
+      const meetBloc = loggedPage?.content.find(_ => _.id === fullPageFormObject.getBloc("firstMeets").dataTestId)
+      console.log(meetBloc)
+      expect((meetBloc as Meets)?.meets?.[0]?.date?.toISOString()).to.equal("2012-12-20T07:15:00.000Z")
+    })
+  })
+})

--- a/cypress/integration/components/page/pageForm/meets/items.ts
+++ b/cypress/integration/components/page/pageForm/meets/items.ts
@@ -1,0 +1,27 @@
+import { Meets, Page } from "$model/Page"
+import { fullPageFormObject } from "../common"
+
+describe("MeetsEdit items", () => {
+  it("should add an item", () => {
+    fullPageFormObject.initialize()
+
+    fullPageFormObject.getBloc("firstMeets").addItem()
+    fullPageFormObject.getBloc("firstMeets").itemShouldExist(2)
+  })
+
+  it("should remove the first item", () => {
+    fullPageFormObject.initialize()
+
+    fullPageFormObject.getBloc("firstMeets").deleteItem(0)
+    fullPageFormObject.getBloc("firstMeets").itemShouldNotExist(2)
+    fullPageFormObject.getBloc("firstMeets").attributeDatetimeOfTimeShouldBe(0, "2021-05-23T20:00:00.000Z")
+  })
+
+  it("should remove the second item", () => {
+    fullPageFormObject.initialize()
+
+    fullPageFormObject.getBloc("firstMeets").deleteItem(1)
+    fullPageFormObject.getBloc("firstMeets").itemShouldNotExist(2)
+    fullPageFormObject.getBloc("firstMeets").attributeDatetimeOfTimeShouldBe(0, "2021-05-22T15:30:00.000Z")
+  })
+})

--- a/src/lib/components/bloc/bloc/BlocEdit.svelte
+++ b/src/lib/components/bloc/bloc/BlocEdit.svelte
@@ -4,6 +4,7 @@
   import type { Move } from "$lib/components/types"
   import TextEdit from "$lib/components/bloc/text/TextEdit.svelte"
   import MeetEdit from "$lib/components/bloc/meet/MeetEdit.svelte"
+  import MeetsEdit from "$lib/components/bloc/meets/MeetsEdit.svelte"
   import ImageEdit from "$lib/components/bloc/image/ImageEdit.svelte"
 
   export let bloc: Bloc
@@ -22,6 +23,7 @@
     h5: TextEdit,
     h6: TextEdit,
     meet: MeetEdit,
+    meets: MeetsEdit,
     img: ImageEdit,
   }
 

--- a/src/lib/components/bloc/bloc/BlocTransformer.ts
+++ b/src/lib/components/bloc/bloc/BlocTransformer.ts
@@ -1,4 +1,5 @@
-import type { Bloc, Image, Meet, Text, TextPart } from "$model/Page"
+import { generateId } from "$lib/utils/strings"
+import type { Bloc, Image, Meet, Meets, Text, TextPart } from "$model/Page"
 
 export function transformBloc(bloc: Bloc, target: Bloc["type"]): Bloc {
   switch (bloc.type) {
@@ -12,6 +13,8 @@ export function transformBloc(bloc: Bloc, target: Bloc["type"]): Bloc {
       return transformText(bloc, target)
     case "meet":
       return transformMeet(bloc, target)
+    case "meets":
+      return transformMeets(bloc, target)
     case "img":
       return transformImage(bloc, target)
   }
@@ -33,6 +36,8 @@ function transformText(text: Text, target: Bloc["type"]): Bloc {
       }
     case "meet":
       return buildMeet({ id: text.id })
+    case "meets":
+      return buildMeets({ id: text.id })
     case "img":
       return buildImage({ id: text.id })
   }
@@ -54,8 +59,33 @@ function transformMeet(meet: Meet, target: Bloc["type"]): Bloc {
       }
     case "meet":
       return meet
+    case "meets":
+      return buildMeets({ id: meet.id, meets: [meet] })
     case "img":
       return buildImage({ id: meet.id })
+  }
+}
+
+function transformMeets(meets: Meets, target: Bloc["type"]): Bloc {
+  switch (target) {
+    case "p":
+    case "h1":
+    case "h2":
+    case "h3":
+    case "h4":
+    case "h5":
+    case "h6":
+      return {
+        type: target,
+        id: meets.id,
+        content: []
+      }
+    case "meet":
+      return buildMeet({ id: meets.id, date: meets.meets[0]?.date, members: meets.meets[0]?.members })
+    case "meets":
+      return meets
+    case "img":
+      return buildImage({ id: meets.id })
   }
 }
 
@@ -75,6 +105,8 @@ function transformImage(image: Image, target: Bloc["type"]): Bloc {
       }
     case "meet":
       return buildMeet({ id: image.id })
+    case "meets":
+      return buildMeets({ id: image.id })
     case "img":
       return image
   }
@@ -99,13 +131,27 @@ function buildText({ id, type, content }: BuildTextParameters): Text {
 
 type BuildMeetParameters = {
   id: string
+  date?: Date
+  members?: Array<string>
 }
-function buildMeet({ id }: BuildMeetParameters): Meet {
+function buildMeet({ id, date, members }: BuildMeetParameters): Meet {
   return {
     type: "meet",
     id: id,
-    date: new Date(Date.now()),
-    members: []
+    date: date ?? new Date(Date.now()),
+    members: members ?? []
+  }
+}
+
+type BuildMeetsParameters = {
+  id: string
+  meets?: Array<Meet>
+}
+function buildMeets({ id, meets }: BuildMeetsParameters): Meets {
+  return {
+    type: "meets",
+    id: id,
+    meets: meets ?? [buildMeet({ id: generateId() })]
   }
 }
 

--- a/src/lib/components/bloc/bloc/BlocView.svelte
+++ b/src/lib/components/bloc/bloc/BlocView.svelte
@@ -2,6 +2,7 @@
   import type { Bloc } from "$model/Page"
   import TextView from "../text/TextView.svelte"
   import MeetView from "../meet/MeetView.svelte"
+  import MeetsView from "../meets/MeetsView.svelte";
   import ImageView from "../image/ImageView.svelte"
 
   export let bloc: Bloc
@@ -15,6 +16,7 @@
     h5: TextView,
     h6: TextView,
     meet: MeetView,
+    meets: MeetsView,
     img: ImageView,
   }
 </script>

--- a/src/lib/components/bloc/meet/MeetEdit.svelte
+++ b/src/lib/components/bloc/meet/MeetEdit.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte"
   import type { Meet } from "$model/Page"
-  import InputDateTime from "$lib/components/form/InputDateTime.svelte"
   import type { PageEditEventDispatcher } from "$lib/components/types"
-  import PrimaryButton from "$lib/components/button/PrimaryButton.svelte"
   import { menuAction } from "$lib/components/page/MenuAction"
-import TagList from "$lib/components/tag/TagList.svelte"
+  import TagList from "$lib/components/tag/TagList.svelte"
+  import EditableDate from "$lib/components/form/EditableDate.svelte"
 
   export let bloc: Meet
   export let index: number
@@ -64,21 +63,7 @@ import TagList from "$lib/components/tag/TagList.svelte"
 
 <div class="meet" data-test-id={bloc.id} use:menuAction={index}>
   <div class="header" class:edit={editingDate}>
-    {#if editingDate}
-      <InputDateTime
-        id={`${bloc.id}-date`}
-        name={`${bloc.id}.date`}
-        dataTestId={`${bloc.id}.date`}
-        value={bloc.date}
-        on:change={onChange}
-      />
-      <PrimaryButton label="✔️" on:click={() => (editingDate = false)} dataTestId={`${bloc.id}-validButton`} />
-    {:else}
-      <time datetime={bloc.date.toISOString()}>
-        {new Intl.DateTimeFormat([], { dateStyle: "full", timeStyle: "short" }).format(bloc.date)}
-      </time>
-      <PrimaryButton label="🖊" on:click={() => (editingDate = true)} dataTestId={`${bloc.id}-editButton`} />
-    {/if}
+    <EditableDate date={bloc.date} id={bloc.id} dataTestId={bloc.id} on:change={onChange} />
   </div>
 
   <div class="content">

--- a/src/lib/components/bloc/meets/MeetsEdit.svelte
+++ b/src/lib/components/bloc/meets/MeetsEdit.svelte
@@ -1,0 +1,103 @@
+<script lang="ts">
+  import type { Meet, Meets } from "$model/Page"
+  import TagList from "$lib/components/tag/TagList.svelte"
+  import SimpleTextForm from "$lib/components/form/SimpleTextForm.svelte"
+  import { menuAction } from "$lib/components/page/MenuAction"
+  import EditableDate from "$lib/components/form/EditableDate.svelte"
+  import DangerButton from "$lib/components/button/DangerButton.svelte"
+  import { createEventDispatcher } from "svelte"
+  import type { PageEditEventDispatcher } from "$lib/components/types"
+  import PrimaryButton from "$lib/components/button/PrimaryButton.svelte"
+  import { generateId } from "$lib/utils/strings"
+
+  export let bloc: Meets
+  export let index: number
+
+  const dispatch = createEventDispatcher<PageEditEventDispatcher>()
+
+  export function deleteMeet(event: MouseEvent, id: string) {
+    event.preventDefault()
+    dispatch("update", {
+      index,
+      bloc: {
+        ...bloc,
+        meets: bloc.meets.filter((meet) => meet.id !== id),
+      },
+    })
+  }
+
+  export function addMeet(event: MouseEvent) {
+    event.preventDefault()
+
+    const newMeet: Meet = {
+      type: "meet",
+      id: generateId(),
+      date: new Date(),
+      members: [],
+    }
+    dispatch("update", {
+      index,
+      bloc: {
+        ...bloc,
+        meets: [...bloc.meets, newMeet],
+      },
+    })
+  }
+
+</script>
+
+<style>
+  .meets {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: auto auto 1fr auto;
+  }
+
+  .header {
+    font-weight: bold;
+  }
+
+  .form {
+    grid-column-start: 1;
+    grid-column-end: 3;
+  }
+
+</style>
+
+<div class="meets" data-test-id={bloc.id} use:menuAction={index}>
+  <div class="header">Date</div>
+  <div class="header">Register</div>
+  <div class="header">Participants</div>
+  <div class="header" />
+
+  {#each bloc.meets as meet, index}
+    <div>
+      <EditableDate bind:date={meet.date} id={meet.id} dataTestId={`${bloc.id}-meet-${index}-date`} />
+    </div>
+    <input
+      type="checkbox"
+      id={`${bloc.id}-meet-${index}-select`}
+      form={`meets-${bloc.id}`}
+      disabled
+    />
+    <TagList tags={meet.members} />
+    <DangerButton
+      label="Delete"
+      on:click={(event) => deleteMeet(event, meet.id)}
+      dataTestId={`${bloc.id}-meet-${index}-delete`}
+    />
+  {/each}
+
+  <div class="form">
+    <SimpleTextForm
+      label="Your name"
+      id={`meets-${bloc.id}-register`}
+      name="name"
+      submitLabel="Register"
+      formName={`meets-${bloc.id}`}
+      disabled
+    />
+  </div>
+  <div />
+  <PrimaryButton label="Add" on:click={addMeet} dataTestId={`${bloc.id}-add`} />
+</div>

--- a/src/lib/components/bloc/meets/MeetsView.svelte
+++ b/src/lib/components/bloc/meets/MeetsView.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { getContext } from "svelte"
+  import type { Meets } from "$model/Page"
+  import { pageValidation } from "$model/validation/PageValidation"
+  import type { PageActions } from "$lib/components/page/PageActions"
+  import TagList from "$lib/components/tag/TagList.svelte"
+  import SimpleTextForm from "$lib/components/form/SimpleTextForm.svelte"
+
+  export let bloc: Meets
+
+  const actions = getContext<PageActions>("actions")
+
+  let selection: Record<string, boolean> = {}
+
+  async function register(
+    event: CustomEvent<{ value: string; clear: () => void }>,
+  ) {
+    const res = await fetch(`page/${actions.getKey()}/action.json`, {
+      method: "POST",
+      body: JSON.stringify({
+        type: "meets.register",
+        bloc: bloc.id,
+        meets: Object.keys(selection).filter((key) => selection[key] === true),
+        name: event.detail.value,
+      }),
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+    })
+    if (res.status === 200) {
+      const body = await res.json()
+      const bodyResult = pageValidation.validate(body)
+      if (bodyResult.ok) {
+        actions.updatePage(bodyResult.value)
+        event.detail.clear()
+        selection = {}
+      } else if (bodyResult.ok === false) {
+        actions.showError("Invalid body result", bodyResult.errors)
+      }
+    }
+  }
+
+</script>
+
+<style>
+  .meets {
+    display: grid;
+    gap: 16px;
+    grid-template-columns: auto auto 1fr;
+  }
+
+  .header {
+    font-weight: bold;
+  }
+
+  .form {
+    grid-column-start: 1;
+    grid-column-end: 3;
+  }
+
+</style>
+
+<div class="meets">
+  <div class="header">Date</div>
+  <div class="header">Register</div>
+  <div class="header">Participants</div>
+
+  {#each bloc.meets as meet}
+    <label for={`meets-${bloc.id}-meet-${meet.id}`}>
+      <time datetime={meet.date.toISOString()}>
+        {new Intl.DateTimeFormat([], {
+          dateStyle: "full",
+          timeStyle: "short",
+        }).format(meet.date)}
+      </time>
+    </label>
+    <input
+      type="checkbox"
+      id={`meets-${bloc.id}-meet-${meet.id}`}
+      form={`meets-${bloc.id}`}
+      bind:checked={selection[meet.id]}
+    />
+    <TagList tags={meet.members} />
+  {/each}
+
+  <div class="form">
+    <SimpleTextForm
+      label="Your name"
+      id={`meets-${bloc.id}-register`}
+      name="name"
+      submitLabel="Register"
+      formName={`meets-${bloc.id}`}
+      on:submit={register}
+    />
+  </div>
+</div>

--- a/src/lib/components/bloc/text/TextEditKeyboardActions.ts
+++ b/src/lib/components/bloc/text/TextEditKeyboardActions.ts
@@ -126,6 +126,11 @@ export const keyboardActions = new KeyboardListener<RequiredDetail>()
 
   .on(" ")
   .withCaret()
+  .filter(prefixPredicate("/meets"))
+  .process(blocTransformer("meets"))
+
+  .on(" ")
+  .withCaret()
   .filter(prefixPredicate("/img"))
   .process(blocTransformer("img"))
 

--- a/src/lib/components/button/DangerButton.svelte
+++ b/src/lib/components/button/DangerButton.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  export let label: string
+  export let dataTestId: string | undefined = undefined
+  export let disabled: boolean = false
+</script>
+
+<button class="danger" data-test-id={dataTestId} disabled={disabled} on:click>
+  {label}
+</button>

--- a/src/lib/components/form/EditableDate.svelte
+++ b/src/lib/components/form/EditableDate.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import { createEventDispatcher } from "svelte"
+
+  import PrimaryButton from "../button/PrimaryButton.svelte"
+  import InputDateTime from "./InputDateTime.svelte"
+
+  export let date: Date
+  export let id: string
+  export let dataTestId: string | undefined = undefined
+
+  let editing: boolean = false
+
+  const dispatch = createEventDispatcher<{ change: Date }>()
+
+  function onChange(event: CustomEvent<Date>): void {
+    date = event.detail
+    dispatch("change", event.detail)
+  }
+
+</script>
+
+<style>
+</style>
+
+{#if editing}
+  <InputDateTime
+    id={`${id}-date`}
+    name={`${id}.date`}
+    dataTestId={`${dataTestId}.date`}
+    value={date}
+    on:change={onChange}
+  />
+  <PrimaryButton
+    label="✔️"
+    on:click={() => (editing = false)}
+    dataTestId={`${dataTestId}-validButton`}
+  />
+{:else}
+  <time datetime={date.toISOString()} data-test-id={dataTestId}>
+    {new Intl.DateTimeFormat([], {
+      dateStyle: "full",
+      timeStyle: "short",
+    }).format(date)}
+  </time>
+  <PrimaryButton
+    label="🖊"
+    on:click={() => (editing = true)}
+    dataTestId={`${dataTestId}-editButton`}
+  />
+{/if}

--- a/src/lib/components/form/SimpleTextForm.svelte
+++ b/src/lib/components/form/SimpleTextForm.svelte
@@ -5,6 +5,8 @@
   export let name: string
   export let id: string
   export let submitLabel: string
+  export let formName: string | undefined = undefined
+  export let disabled: boolean = false
 
   let value: string = ""
 
@@ -61,8 +63,8 @@
 
 </style>
 
-<form on:submit|preventDefault={submit}>
+<form on:submit|preventDefault={submit} name={formName} id={formName}>
   <label for={id}>{label}</label>
-  <input type="text" name={name} placeholder={label} bind:value required />
-  <button class="primary">{submitLabel}</button>
+  <input type="text" name={name} placeholder={label} bind:value required disabled={disabled} />
+  <button class="primary" disabled={disabled}>{submitLabel}</button>
 </form>

--- a/src/lib/components/page/Menu.svelte
+++ b/src/lib/components/page/Menu.svelte
@@ -18,6 +18,7 @@
     { key: "h6", label: "Title 6" },
     { key: "img", label: "Image" },
     { key: "meet", label: "Meet" },
+    { key: "meets", label: "Meets" },
   ]
 
   function toggleMenu() {

--- a/src/model/Page.ts
+++ b/src/model/Page.ts
@@ -4,7 +4,7 @@ export type Page = {
   content: Array<Bloc>
 }
 
-export type Bloc = Text | Meet | Image
+export type Bloc = Text | Meet | Meets | Image
 
 export type Text = {
   type: "p" | `h${1 | 2 | 3 | 4 | 5 | 6}`
@@ -73,6 +73,12 @@ export type Meet = {
   id: string
   date: Date
   members: Array<string>
+}
+
+export type Meets = {
+  type: "meets"
+  id: string
+  meets: Array<Meet>
 }
 
 export type Image = {

--- a/src/model/validation/PageValidation.ts
+++ b/src/model/validation/PageValidation.ts
@@ -1,6 +1,6 @@
 import type { Validator } from "idonttrustlikethat"
 import { array, literal, object, recursion, string, union } from "idonttrustlikethat"
-import type { Bloc, Emphasis, Image, Link, Meet, Page, PlainText, Strong, Text, TextPart } from "$model/Page"
+import type { Bloc, Emphasis, Image, Link, Meet, Meets, Page, PlainText, Strong, Text, TextPart } from "$model/Page"
 import { dateTime, nonEmptyString } from "$lib/utils/validators"
 import { uniqueBy } from "$lib/utils/arrays"
 
@@ -42,6 +42,12 @@ const meetValidator: Validator<Meet> = object({
   members: array(nonEmptyString),
 })
 
+const meetsValidator: Validator<Meets> = object({
+  type: literal("meets"),
+  id: nonEmptyString,
+  meets: array(meetValidator)
+})
+
 const imageValidator: Validator<Image> = object({
   type: literal("img"),
   id: nonEmptyString,
@@ -50,7 +56,7 @@ const imageValidator: Validator<Image> = object({
   caption: string.optional()
 })
 
-const blocValidator: Validator<Bloc> = union(textValidator, meetValidator, imageValidator)
+const blocValidator: Validator<Bloc> = union(textValidator, meetValidator, meetsValidator, imageValidator)
 
 export const pageValidation: Validator<Page> = object({
   key: nonEmptyString,

--- a/src/routes/tests/PageFormTest.ts
+++ b/src/routes/tests/PageFormTest.ts
@@ -74,13 +74,36 @@ const initialPage: Page = {
     {
       "id": "gMOtIVioNzk1khxGplXl",
       "type": "h1",
-      "content": [text("Meets")]
+      "content": [text("Meet")]
     },
     {
       "id": "hBZZT83U4fvFaZq2I1wo",
       "type": "meet",
       "date": new Date(Date.parse("2021-03-01T20:30:00Z")),
       "members": ["John"]
+    },
+    {
+      "id": "FpJ2UnQZjd3zJbgnRNvY",
+      "type": "h1",
+      "content": [text("Meets")]
+    },
+    {
+      "id": "CHK4tT7mOwSyQ9i6XFrU",
+      "type": "meets",
+      "meets": [
+        {
+          "type": "meet",
+          "id": "jfsw9n87X51Ssz37EEIq",
+          "date": new Date(Date.parse("2021-05-22T15:30:00Z")),
+          "members": ["Edouard"]
+        },
+        {
+          "type": "meet",
+          "id": "oRCn9u4Bb89juITcjEC9",
+          "date": new Date(Date.parse("2021-05-23T20:00:00Z")),
+          "members": ["James", "Philippe"]
+        }
+      ]
     },
     {
       "id": "BzJo1laUPQWrpbb3x574",

--- a/src/server/persistence/PageRepository.ts
+++ b/src/server/persistence/PageRepository.ts
@@ -5,12 +5,16 @@ const defaultHomePage: Page = {
   key: "home",
   title: "Home",
   content: [
-    { id: generateId(), type: "h1", content: [{type: "text", content: "Title 1"}] },
-    { id: generateId(), type: "h2", content: [{type: "text", content: "Title 2"}] },
-    { id: generateId(), type: "p", content: [{type: "text", content: "Welcome here!"}] },
-    { id: generateId(), type: "p", content: [{type: "text", content: "The application is started."}] },
-    { id: generateId(), type: "p", content: [{type: "text", content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla id finibus mauris. Morbi et porta nisl, vitae efficitur tellus. Etiam id cursus lectus, eu faucibus diam. Suspendisse fermentum magna eu justo elementum sagittis. Donec eget malesuada elit, nec gravida ligula. Aenean ut odio in elit pharetra volutpat. Phasellus finibus leo et ipsum vestibulum, vitae semper ligula venenatis. Mauris quam lectus, aliquam vitae sapien in, imperdiet eleifend dolor. Curabitur pharetra maximus sagittis. Donec dignissim eu nisi sed viverra. Vivamus cursus erat eu ligula auctor, in fringilla libero congue. Maecenas erat nisi, sagittis vitae mi nec, tincidunt hendrerit lectus. Nulla lobortis mollis tristique. Aliquam erat volutpat. "}] },
+    { id: generateId(), type: "h1", content: [{ type: "text", content: "Title 1" }] },
+    { id: generateId(), type: "h2", content: [{ type: "text", content: "Title 2" }] },
+    { id: generateId(), type: "p", content: [{ type: "text", content: "Welcome here!" }] },
+    { id: generateId(), type: "p", content: [{ type: "text", content: "The application is started." }] },
+    { id: generateId(), type: "p", content: [{ type: "text", content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla id finibus mauris. Morbi et porta nisl, vitae efficitur tellus. Etiam id cursus lectus, eu faucibus diam. Suspendisse fermentum magna eu justo elementum sagittis. Donec eget malesuada elit, nec gravida ligula. Aenean ut odio in elit pharetra volutpat. Phasellus finibus leo et ipsum vestibulum, vitae semper ligula venenatis. Mauris quam lectus, aliquam vitae sapien in, imperdiet eleifend dolor. Curabitur pharetra maximus sagittis. Donec dignissim eu nisi sed viverra. Vivamus cursus erat eu ligula auctor, in fringilla libero congue. Maecenas erat nisi, sagittis vitae mi nec, tincidunt hendrerit lectus. Nulla lobortis mollis tristique. Aliquam erat volutpat. " }] },
     { id: generateId(), type: "meet", date: new Date(), members: ["Arthur"] },
+    { id: generateId(), type: "meets", meets: [
+      { id: generateId(), type: "meet", date: new Date(), members: ["Arthur"] },
+      { id: generateId(), type: "meet", date: new Date(), members: ["George"] },
+    ] },
     { id: generateId(), type: "img", src: "https://place-hold.it/500x300", alt: "sample image", caption: "Sample image from place-hold.it" },
   ]
 }

--- a/static/global.css
+++ b/static/global.css
@@ -72,17 +72,38 @@ label {
 	margin-bottom: 8px;
 }
 
-button.primary, a.primary {
-  background-color: #6B9AC4;
+button.primary, a.primary, button.danger {
 	text-decoration: none;
 	border-radius: 4px;
 	border: none;
-	color: #ffffff;
 	padding: 8px 12px;
 	font-size: 14px;
 	line-height: 16px;
 	cursor: pointer;
 	transition: all ease-in-out 250ms;
+}
+
+button.primary, a.primary {
+  background-color: #6B9AC4;
+	color: #ffffff;
+}
+
+button.primary:hover:not([disabled]), a.primary:hover {
+	box-shadow: 0px 2px 4px rgba(35, 63, 88, 0.5);
+}
+
+button.primary:active:not([disabled]), a.primary:active {
+	box-shadow: inset 0px 2px 4px rgba(35, 63, 88, 0.5);
+}
+
+button.primary[disabled] {
+	background-color: #A7C4DC;
+	cursor: not-allowed;
+}
+
+button.danger, a.danger {
+  background-color: #DB162F;
+	color: #ffffff;
 }
 
 button.primary:hover:not([disabled]), a.primary:hover {


### PR DESCRIPTION
We can add a meet in the page.
However, when we want to give the user a choice among several dates, it becomes quite cluttered.
We improve the user experience by introducing another bloc named `MeetsBloc`.

The main difference is that there are several dates in the same bloc and the registration process differs.

This commit does the following:

* Add `MeetsView`, `MeetsEdit` and there respective action and validation
* Extract component `EditableDate` to be the same across `Meet` and `Meets` blocs
* Add tests ensuring the behavior